### PR TITLE
Feature/yeonkyoung

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@types/react-dom": "^18.0.11",
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.3.4",
-        "eslint-plugin-jest": "^27.2.1",
         "jest": "^27.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -37,6 +36,7 @@
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-react": "^7.32.2",
         "husky": "^8.0.3",
         "prettier": "^2.8.4"
@@ -7371,6 +7371,7 @@
       "version": "27.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
       "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
       },
@@ -22808,6 +22809,7 @@
       "version": "27.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
       "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,79 @@
+import { useEffect, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import DataContext from './apis/contextAPI';
+import Table from './components/Table';
+import useFilterData from './hooks/useFilterData';
+
 function App() {
+  const [filteredData] = useFilterData();
+  const [index, setIndex] = useState(1);
+  const [idSort, setIdSort] = useState(false);
+  const [transactionSort, setTransactionSort] = useState(false);
+
+  const [buttons, setButtons] = useState<number[]>([]);
+
+  const handleButton = (index: number) => {
+    setIndex(index);
+  };
+
+  const handleIdButton = () => {
+    setIdSort(prev => !prev);
+    setTransactionSort(false);
+  };
+
+  const handleTransactionButton = () => {
+    setTransactionSort(prev => !prev);
+    setIdSort(false);
+  };
+
+  useEffect(() => {
+    if (filteredData) {
+      setButtons(
+        Array.from(
+          { length: filteredData?.length - 1 },
+          (_, index) => index + 1
+        )
+      );
+    }
+  }, [filteredData]);
+
+  if (filteredData) {
+    return (
+      <DataContext.Provider
+        value={{ filteredData, index, idSort, transactionSort }}>
+        <Outlet />
+
+        <table>
+          <thead>
+            <tr>
+              <th>
+                <button onClick={handleIdButton}>
+                  주문번호<span>{idSort ? '↑' : '↓'}</span>
+                </button>
+              </th>
+              <th>
+                <button onClick={handleTransactionButton}>
+                  거래일 & 거래시간<span>{transactionSort ? '↑' : '↓'}</span>
+                </button>
+              </th>
+              <th>주문처리상태</th>
+              <th>고객번호</th>
+              <th>고객이름</th>
+              <th>가격</th>
+            </tr>
+          </thead>
+          <Table />
+        </table>
+        {buttons.map(item => (
+          <button onClick={() => handleButton(item)} key={item}>
+            {item}
+          </button>
+        ))}
+      </DataContext.Provider>
+    );
+  }
+
   return <Outlet />;
 }
 

--- a/src/apis/contextAPI.tsx
+++ b/src/apis/contextAPI.tsx
@@ -1,0 +1,23 @@
+import { createContext } from 'react';
+
+import { contextValue } from '../types/type';
+
+export const DataContext = createContext<contextValue>({
+  filteredData: [
+    [
+      {
+        id: 0,
+        transaction_time: '',
+        status: false,
+        customer_id: 0,
+        customer_name: '',
+        currency: '',
+      },
+    ],
+  ],
+  index: 1,
+  idSort: false,
+  transactionSort: false,
+});
+
+export default DataContext;

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -10,5 +10,4 @@ const instance = axios.create({
 });
 
 export default instance;
-
-export const chartApi = () => instance.get('');
+export const get = () => instance.get('');

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,20 @@
+import useSortData from '../hooks/useSortData';
+
+function Table() {
+  const [sortedData] = useSortData();
+  return (
+    <tbody>
+      {sortedData?.map(item => (
+        <tr key={item.id}>
+          <td>{item.id}</td>
+          <td>{item.transaction_time}</td>
+          <td>{item.status}</td>
+          <td>{item.customer_id}</td>
+          <td>{item.customer_name}</td>
+          <td>{item.currency}</td>
+        </tr>
+      ))}
+    </tbody>
+  );
+}
+export default Table;

--- a/src/hooks/useFilterData.ts
+++ b/src/hooks/useFilterData.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+import { get } from '../apis/instance';
+import { DataType, FunctionType } from '../types/type';
+
+const today = '2023-03-08';
+function useFilterData() {
+  const [filteredData, setFilteredData] = useState<DataType[][]>();
+  let data: DataType[] | null = null;
+  const findDate = (date: string) => {
+    const todayDate = new Date(date);
+    const tmp = [];
+    tmp.push(todayDate.getFullYear());
+    tmp.push((todayDate.getMonth() + 1).toString().padStart(2, '0'));
+    tmp.push(todayDate.getDate().toString().padStart(2, '0'));
+    return tmp.join('-').toString();
+  };
+  const filterTodayData = (findDate: FunctionType) => {
+    const todayData = data?.filter(
+      item => today === findDate(item.transaction_time)
+    );
+    return todayData;
+  };
+  const pagenationData = (data: DataType[]) => {
+    const arr = [];
+    for (let i = 0; i < data.length; i += 50) {
+      arr.push(data.slice(i, i + 50));
+    }
+    setFilteredData(arr);
+  };
+
+  const init = async () => {
+    await get().then(response => (data = response.data));
+    const todayData = filterTodayData(findDate); //data :filteredData
+    if (todayData) {
+      pagenationData(todayData);
+    }
+  };
+  useEffect(() => {
+    init();
+  }, []);
+  return [filteredData];
+}
+
+export default useFilterData;

--- a/src/hooks/useSortData.ts
+++ b/src/hooks/useSortData.ts
@@ -1,0 +1,43 @@
+import { useContext, useEffect, useState } from 'react';
+
+import DataContext from '../apis/contextAPI';
+
+function useSortData() {
+  const { filteredData, index, idSort, transactionSort } =
+    useContext(DataContext);
+  const [sortedData, setSortedData] = useState([...filteredData[index]]);
+
+  const sortData = () => {
+    const tmpData = [...sortedData];
+    if (idSort) {
+      setSortedData(
+        tmpData.sort(function (a, b) {
+          if (a.customer_id > b.customer_id) return -1;
+          else if (b.customer_id > a.customer_id) return 1;
+          else return 0;
+        })
+      );
+      return;
+    }
+    if (transactionSort) {
+      setSortedData(
+        tmpData.sort(function (a, b) {
+          if (a.transaction_time > b.transaction_time) return -1;
+          else if (b.transaction_time > a.transaction_time) return 1;
+          else return 0;
+        })
+      );
+      return;
+    }
+  };
+  const init = () => {
+    setSortedData([...filteredData[index]]);
+  };
+  useEffect(() => {
+    init();
+    sortData();
+  }, [idSort, transactionSort, index]);
+
+  return [sortedData];
+}
+export default useSortData;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,8 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
 import router from './shared/Router';
-import GlobalStyle from './styles/GlobalStyle';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
-root.render(
-  <>
-    <GlobalStyle />
-    <RouterProvider router={router} />
-  </>
-);
+root.render(<RouterProvider router={router} />);

--- a/src/types/type.d.ts
+++ b/src/types/type.d.ts
@@ -1,0 +1,18 @@
+export interface DataType {
+  id: number;
+  transaction_time: string;
+  status: boolean;
+  customer_id: number;
+  customer_name: string;
+  currency: string;
+}
+
+export interface contextValue {
+  filteredData: DataTypeArray[];
+  index: number;
+  idSort: boolean;
+  transactionSort: boolean;
+}
+export type DataTypeArray = DataType[];
+
+export type FunctionType = (value: string) => string;


### PR DESCRIPTION
## 요구사항

1. 주문 목록 페이지 구현
 - [x] 테이블 형태
 - [x] 페이지네이션(50건의 주문 데이터)
 - [x] 오늘의 거래 건만 보여지기
2. 정렬 기능 구현
 - [ ] `ID` 기준 오름차순 구현
 - [x] `주문번호` 버튼 클릭시 내림차순 정렬
 - [x] `거래일 & 거래시간` 버튼 클릭시 내림차순 정렬

## 구현 방법
- table 태그 사용
- 1페이지 가장 위 데이터를 기준
- 커스텀훅 useFilterData로 `오늘`데이터 필터링 기능 구현
- 커스텀훅 useFilterData로  `페이지네이션` 기능 구현
- 커스텀훅  useSortData로 `정렬` 기능 구현

## 부족한 부분
- 코드 분리가 잘 되지 못한 점
- react-query로 페이지네이션을 구현하지 못하고 커스텀 훅으로 구현
- 정렬을 선택했다면.. 해당 페이지만 정렬이 적용되는게 맞을까요?

## 수정한 부분
 - [x] `ID` 기준 오름차순 구현